### PR TITLE
Fix TreeMap collision crash and runtime errors

### DIFF
--- a/js/App.vue
+++ b/js/App.vue
@@ -558,7 +558,7 @@ export default {
             this.fetchYoutubeTrophies().then(async (trophies: YoutubeTrophy[]) => {
                 for (const youtubeTrophy of trophies) {
                     for (const gambit of Object.keys(this.displayableGambits)) {
-                        if (youtubeTrophy.title.includes(this.shortNames.get(gambit) || gambit)) {
+                        if (youtubeTrophy.title?.includes(this.shortNames.get(gambit) || gambit)) {
                             this.displayableGambits[gambit].Videos.push(youtubeTrophy)
                             this.youtubeVideosCount++
                         }
@@ -636,6 +636,9 @@ export default {
             exportAsCsv(playerTrophiesByType, this.username)
         },
         addTrophyForPlayer(trophyName: string, game: Game, onMoveNumber?: number): void {
+            if (!this.displayableGambits[trophyName]) {
+                return
+            }
             if (this.displayableGambits[trophyName].Trophies[game.id]) {
                 return
             }

--- a/js/utils/TreeMap.ts
+++ b/js/utils/TreeMap.ts
@@ -13,31 +13,20 @@ export class TreeMap<K, V> {
                 node = newNode
             }
         }
-        this.add(key, node, value)
-    }
-    private add(key: K[], node: TreeNode<K, V>, value: V) {
-        if (node.value !== undefined) {
-            throw new Error(`Key ${key.join(',')} already has a value ${node.value}, cannot add ${value}`)
-        } else {
-            node.value = value
-        }
+        node.values.push(value)
     }
     public get(key: Iterable<K>): V[] {
         return this.getMap(key, (a: K) => a)
     }
     public getMap<U>(key: Iterable<U>, map: (x: U) => K): V[] {
-        const result = new Array()
+        const result = new Array<V>()
         let node = this.root
-        if (node.value != undefined) {
-            result.push(node.value)
-        }
+        result.push(...node.values)
         for (const next of key) {
             const exists = node.children.get(map(next))
             if (exists !== undefined) {
                 node = exists
-                if (node.value != undefined) {
-                    result.push(node.value)
-                }
+                result.push(...node.values)
             } else {
                 return result
             }
@@ -46,7 +35,7 @@ export class TreeMap<K, V> {
     }
 }
 class TreeNode<K, V> {
-    public value?: V
+    public values: V[] = []
     public children: Map<K, TreeNode<K, V>> = new Map<K, TreeNode<K, V>>()
 }
 

--- a/tests/tree-map.test.ts
+++ b/tests/tree-map.test.ts
@@ -58,14 +58,15 @@ describe('test tree map', () => {
     })
 })
 
-describe('Test error case of TreeMap', () =>
+describe('Test duplicate keys in TreeMap', () =>
     test.each([
-        { k: 'abc', v: 1 },
-        { k: '', v: 2 },
-    ])('Error should be thrown after inserting the same key', (keyValuePair) => {
+        { k: 'abc', v1: 1, v2: 2 },
+        { k: '', v1: 10, v2: 20 },
+    ])('Duplicate keys accumulate values instead of throwing', (pair) => {
         const treeMap = new TreeMap()
-        treeMap.set(keyValuePair.k.split(''), keyValuePair.v)
-        expect(() => treeMap.set(keyValuePair.k.split(''), keyValuePair.v)).toThrowError()
+        treeMap.set(pair.k.split(''), pair.v1)
+        treeMap.set(pair.k.split(''), pair.v2)
+        expect(treeMap.get(pair.k.split(''))).toEqual([pair.v1, pair.v2])
     }))
 
 describe('Test mapIterator', () =>


### PR DESCRIPTION
## Summary

- **TreeMap collision**: `TreeMap` threw when two gambits shared the same PGN prefix (Hamppe-Muzio Gambit variants, Basque Gambit variants). Changed `value?: V` to `values: V[]` so multiple gambits at the same node are stored and returned correctly. Also covers two pre-existing collisions (C27 Boden-Kieseritzky duplicate, C39 Kieseritzky/Rice name variant).
- **addTrophyForPlayer crash**: Added a null-guard so a gambit name absent from `displayableGambits` silently skips instead of throwing `Cannot read properties of undefined (reading 'Trophies')`.
- **YouTube title crash**: Used optional chaining `youtubeTrophy.title?.includes(...)` to handle entries where the YouTube API returns an object without a title field.

## Test plan

- [x] Load a username — no TreeMap errors in console
- [x] Gambits with shared PGN prefix (Hamppe-Muzio, Basque Gambit) both appear in results
- [x] Load a cached username — no `Cannot read/set properties of undefined` errors
- [x] No console errors on any path through the app

Generated with [Claude Code](https://claude.com/claude-code)