### PR TITLE
Surface gambit comment annotations below chessboard preview

### DIFF
--- a/js/App.vue
+++ b/js/App.vue
@@ -265,6 +265,7 @@
                         :gambit-fen="gambit.opening.fen"
                         :moveNumber="gambit.opening.move"
                         :youtube="gambit.Videos || []"
+                        :comment="gambit.opening.comment"
                     ></accomplishment-score>
                 </div>
             </div>

--- a/js/components/AccomplishmentScore.vue
+++ b/js/components/AccomplishmentScore.vue
@@ -87,6 +87,7 @@
 
             <template #popper>
                 <TheChessboard :board-config="boardConfig" />
+                <p v-if="comment" class="max-w-xs p-2 text-xs italic text-gray-300">{{ comment }}</p>
             </template>
         </VTooltip>
 
@@ -123,7 +124,6 @@
                     </svg>
                     Watch Video
                 </a>
-                <p v-if="comment" class="mt-2 text-xs italic text-left opacity-80">{{ comment }}</p>
             </div>
 
             <template v-if="hasTrophies">

--- a/js/components/AccomplishmentScore.vue
+++ b/js/components/AccomplishmentScore.vue
@@ -123,6 +123,7 @@
                     </svg>
                     Watch Video
                 </a>
+                <p v-if="comment" class="mt-2 text-xs italic text-left opacity-80">{{ comment }}</p>
             </div>
 
             <template v-if="hasTrophies">
@@ -189,6 +190,7 @@ export default {
             required: true,
         },
         youtubeLink: String,
+        comment: String,
         site: String,
         youtube: {
             type: Array,


### PR DESCRIPTION
## Summary

- Adds a `comment` prop to `AccomplishmentScore.vue`
- When hovering a gambit card, the curator note (if any) appears below the chessboard board preview in the same tooltip
- These notes explain why the PGN differs from the Lichess source database (e.g. why a line was shortened or extended)
- Passes `gambit.opening.comment` from `App.vue` -- no data changes required

## Test plan

- Hover any gambit card with a modified PGN (e.g. Smith-Morra Gambit) -- note appears in italic below the chessboard
- Cards without a comment show only the chessboard, no extra text
- npm test passes (38/38)